### PR TITLE
added prework usage image

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ N/A
 
 This webpage can be used to review notes that I have taken as I was going through the prework material. TO review the notes, open the webpage containing the four topics: HTML, CSS, Git, and JavaScript. For suggestions on what to study first, open the Chrome DevTools by pressing Command+Option+I (macOS) or Control+Shift+I (Windows). A console panel should open either below or to the side of the webpage in the browser. There you will see a list of topics we learned from the prework along with a suggestion on which topic to study first.
 
-![prework study guide](prework-study-guide\assets\prework_study_guide_usage.png)
+<img width="1359" alt="prework_study_guide_usage" src="https://user-images.githubusercontent.com/112888008/193068919-fabee69a-1c15-4cd6-b908-85113f93695d.png">
 
 ## Credits
 


### PR DESCRIPTION
added prework study guide usage image using a drag and drop technique in GitHub instead of the ![alt text](assets/images/screenshot.png) method used in the README template lesson.